### PR TITLE
fix: limit github reporter payload size

### DIFF
--- a/cli/src/reporters/github.js
+++ b/cli/src/reporters/github.js
@@ -5,13 +5,13 @@ let API = 'https://bundlesize-github-reporter.now.sh'
 // if (ci === 'custom') API = 'http://localhost:3000'
 
 async function report(summary) {
-  const body = {
-    repo,
-    sha,
-    status: summary.status,
-    title: summary.title,
-    text: summary.details,
-  }
+  const { status, title, details } = summary
+  const text =
+    details > 60000
+      ? details.substring(0, 60000) + '… (message truncated)'
+      : details
+
+  const body = { repo, sha, status, title, text }
 
   await fetch(API, {
     method: 'post',

--- a/cli/src/utils/summarize.js
+++ b/cli/src/utils/summarize.js
@@ -64,7 +64,7 @@ function getRow({ file, cachedFile, row, maxFileLength, baseBranch, colors }) {
   return [
     ' ',
     symbol,
-    rightpad(file.path, maxFileLength),
+    rightpad(file.path, Math.min(maxFileLength, 100)),
     '  ',
     bytes(file.size),
     operator,


### PR DESCRIPTION
GitHub checks API has a limit on the size of the payload it receives. 

This change ensures that all requests are within this limit.

See issue https://github.com/siddharthkp/bundlesize2/issues/7 for more details.