### PR TITLE
fix: correct check logo src

### DIFF
--- a/github-reporter/_check.js
+++ b/github-reporter/_check.js
@@ -72,11 +72,11 @@ const run = async ({
     text
       .replace(
         /✔/g,
-        '<img src="https://raw.githubusercontent.com/siddharthkp/bundlesize2/master/github-reporter/public/check-pass.svg"></img>'
+        '<img src="https://raw.githubusercontent.com/siddharthkp/bundlesize2/main/github-reporter/public/check-pass.svg"></img>'
       )
       .replace(
         /✖/g,
-        '<img src="https://raw.githubusercontent.com/siddharthkp/bundlesize2/master/github-reporter/public/check-fail.svg"></img>'
+        '<img src="https://raw.githubusercontent.com/siddharthkp/bundlesize2/main/github-reporter/public/check-fail.svg"></img>'
       ) +
     '</pre>'
 


### PR DESCRIPTION
The image URL is currently pointing to:

/siddharthkp/bundlesize2/master/github-reporter/public/check-*.svg

but it now needs to be:

/siddharthkp/bundlesize2/main/github-reporter/public/check-*.svg

See issue at https://github.com/siddharthkp/bundlesize2/issues/12