### PR TITLE
fix: reduce limit again

### DIFF
--- a/cli/src/reporters/github.js
+++ b/cli/src/reporters/github.js
@@ -7,8 +7,8 @@ let API = 'https://bundlesize-github-reporter.now.sh'
 async function report(summary) {
   const { status, title, details } = summary
   const text =
-    details > 60000
-      ? details.substring(0, 60000) + '… (message truncated)'
+    details > 50000
+      ? details.substring(0, 50000) + '… (message truncated)'
       : details
 
   const body = { repo, sha, status, title, text }


### PR DESCRIPTION
Reducing the limit to avoid the GitHub limit error:

```
⚠️ Could not add check

        Something broke pretty bad!

        Please create an issue with this error message: HttpError: Invalid request.

Only 65535 characters are allowed; 65779 were supplied.
```