### PR TITLE
Updating node-fetch to 2.6.7

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -19,7 +19,7 @@
     "figures": "^3.2.0",
     "glob": "^7.1.6",
     "gzip-size": "^5.1.1",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.7",
     "plur": "^4.0.0",
     "right-pad": "^1.0.1"
   },


### PR DESCRIPTION
It's a security patch release: https://github.com/node-fetch/node-fetch/releases/tag/v2.6.7